### PR TITLE
fix useless private access modifier

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,9 @@ Layout/CaseIndentation:
 
 Layout/LineLength:
   AllowedPatterns: ['\A#'] # Allow long comments (annotate gem might generates long comments)
+
+Lint/UselessAccessModifier:
+  ContextCreatingMethods:
+    - concerning
+    - class_methods
+    - included


### PR DESCRIPTION
The problem:

```ruby
module DataDogLogger
  extend ActiveSupport::Concern

  class_methods do
    private

    def data_dog(event, *params)
      DataDogService.instance.public_send(event, *params)
    end
  end

  included do
    private # Rubocop said this private is redundant because it was declared above, but this is a different scope

    def data_dog(event, *params)
      self.class.send(:data_dog, event, *params)
    end
  end
end
```