### PR TITLE
[DEV-5977] Use `[a, [b, c]]` not `[ a, [ b, c ] ]`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,11 +90,11 @@ Layout/SpaceBeforeFirstArg:
 Layout/SpaceInLambdaLiteral:
   Enabled: true
 
-# Use `[ a, [ b, c ] ]` not `[a, [b, c]]`
+# Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Use `[]` not `[ ]`
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true
-  EnforcedStyle: space
+  EnforcedStyle: no_space
   EnforcedStyleForEmptyBrackets: no_space
 
 # Use `%w[ a b ]` not `%w[ a   b ]`.


### PR DESCRIPTION
[DEV-5977](https://www.notion.so/gocheetah/INT-Apply-new-rules-for-rubocop-18a61609d7f78017b7b9c206179c7aa8?pvs=4)
![image](https://github.com/user-attachments/assets/1b4be203-8853-4edf-994d-beb55360912a)
