### PR TITLE
[DEV-5977] Disable NamedSubject

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -197,6 +197,9 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Max: 7
 
+RSpec/NamedSubject:
+  Enabled: false
+
 # We generally prefer &&/|| but like low-precedence and/or in context
 Style/AndOr:
   Enabled: false


### PR DESCRIPTION
[Cop::RSpec::NamedSubject](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject)






![image](https://github.com/user-attachments/assets/c1dcb879-fc6a-49f1-83d7-46f6d4765414)
